### PR TITLE
Update template file to have open to "Existing" option in GitLab

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -28,7 +28,6 @@ services:
       repo_name: '{{toolchain.name}}'
       repo_url: 'https://git.ng.bluemix.net/{{toolchain.name}}/{{toolchain.name}}'
       type: link
-      has_issues: true
       enable_traceability: true
   sample-build:
     service_id: pipeline

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -27,7 +27,7 @@ services:
     parameters:
       repo_name: '{{toolchain.name}}'
       repo_url: 'https://git.ng.bluemix.net/{{toolchain.name}}/{{toolchain.name}}'
-      type: existing
+      type: link
       has_issues: true
       enable_traceability: true
   sample-build:


### PR DESCRIPTION
Hi Dimitry - 

Fixed the template.yml file to make sure that it opens on the "Existing" option. (Currently it will open on the "New" option).

Also, I tried out the scenario from the IT2017_Configure Toolchain doc. Just one thing to mention: when you are creating the projects in GitLab and assigning members to those projects you have to assign them a role. By default it is Guest. You have to assign them "Master" role in order for the enable Traceability feature to work. 

If you don't want to do that, I can help change the template. Feel free to ping me on Slack.